### PR TITLE
DEBUG: Aplicar versiones esqueleto a wizard-manager y app.js

### DIFF
--- a/idx.html
+++ b/idx.html
@@ -5,27 +5,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>FlowWare - Asistente de Configuración</title>
-    <!-- <link rel="stylesheet" href="./styles/components.css"> Eliminado -->
-    <!-- <link rel="stylesheet" href="./styles/nodes.css"> Eliminado -->
-    <link rel="stylesheet" href="./styles/main.css"> <!-- Contendrá estilos globales y del app-header -->
+    <link rel="stylesheet" href="./styles/main.css">
     <link rel="stylesheet" href="./styles/wizard.css">
 </head>
 
 <body>
     <div class="app">
-        <header class="app-header">
-            <h1 class="logo">
-                <span class="logo-icon">⚡</span>
-                FlowWare
-            </h1>
-            <button id="show-wizard-btn" class="btn btn-accent">
-                <span>✨</span> Configuración Inicial
-            </button>
-        </header>
+        <!-- El header global ha sido eliminado -->
 
         <div class="initial-config-message-container" id="initial-config-message" style="display: none;">
             <h2>Configuración Inicial Completada</h2>
-            <p>La configuración básica del sistema ha sido guardada. Puede revisarla o modificarla en cualquier momento haciendo clic en el botón de 'Configuración Inicial' en la parte superior.</p>
+            <p>La configuración básica del sistema ha sido guardada.</p>
+            <button id="reopen-wizard-btn" class="btn btn-primary" style="margin-top: 20px;">
+                <span>✏️</span> Revisar o Reiniciar Configuración
+            </button>
         </div>
 
         <!-- El .app-content-wrapper, .sidebar, .workspace han sido eliminados -->
@@ -33,12 +26,12 @@
 
     </div> <!-- Fin div.app -->
 
-    <!-- Wizard Modal (estructura no cambia, solo su contenido y la forma en que se muestra) -->
+    <!-- Wizard Modal -->
     <div id="config-wizard" class="modal-overlay" style="display: none;">
         <div class="modal-content" style="max-width: 700px; width: 90%;">
             <div class="modal-header">
                 <h2>Asistente de Configuración Inicial</h2>
-                <button id="close-wizard-btn" class="modal-close-btn">&times;</button>
+                <button id="close-wizard-btn" class="modal-close-btn">&times;</button> <!-- Botón para cerrar el wizard -->
             </div>
             <div class="wizard-steps">
                 <div class="wizard-step active" data-step="1">

--- a/js/wizard-manager.js
+++ b/js/wizard-manager.js
@@ -1,94 +1,153 @@
-// js/wizard-manager.js (VERSIÓN ESQUELETO PARA DEPURAR)
-console.log("wizard-manager.js: Script start parsing...");
+// js/wizard-manager.js (VERSIÓN ESQUELETO MÍNIMA PARA DEPURAR Y FLUJO AUTOMÁTICO - V4 con más logs)
+console.log("wizard-manager.js (Skeleton V4): Script start parsing...");
 
 class WizardManager {
     constructor() {
-        console.log("WizardManager CONSTRUCTOR CALLED (Skeleton Version)");
+        console.log("WizardManager CONSTRUCTOR (Skeleton V4) CALLED");
 
         this.wizardElement = document.getElementById('config-wizard');
+        this.initialConfigMessage = document.getElementById('initial-config-message');
+        this.reopenWizardBtn = document.getElementById('reopen-wizard-btn');
         this.closeWizardBtn = document.getElementById('close-wizard-btn');
-        this.showWizardBtn = document.getElementById('show-wizard-btn');
-        // ... otros elementos básicos del wizard si son necesarios para initDisplayLogic
+        this.prevBtn = document.getElementById('wizard-prev-btn');
+        this.nextBtn = document.getElementById('wizard-next-btn');
+        this.finishBtn = document.getElementById('wizard-finish-btn');
 
         if (!this.wizardElement) {
-            console.error("WizardManager Skeleton: #config-wizard element NOT FOUND! Cannot proceed with UI logic.");
-        } else {
-            console.log("WizardManager Skeleton: #config-wizard element found.");
-            // Configurar listeners básicos para mostrar/ocultar el wizard si los botones existen
-            if (this.showWizardBtn) {
-                this.showWizardBtn.addEventListener('click', () => this.showWizard());
-            }
-            if (this.closeWizardBtn) {
-                 this.closeWizardBtn.addEventListener('click', () => this.hideWizard());
-            }
+            console.error("WizardManager Skeleton V4: #config-wizard element NOT FOUND! Wizard cannot function.");
+        }
+        if (!this.initialConfigMessage) {
+            console.warn("WizardManager Skeleton V4: #initial-config-message element NOT FOUND! Completion message will not work.");
+        }
+         if (!this.reopenWizardBtn) {
+            console.warn("WizardManager Skeleton V4: #reopen-wizard-btn element NOT FOUND! Reopening wizard from completion message will not work.");
+        }
+        if (!this.closeWizardBtn || !this.prevBtn || !this.nextBtn || !this.finishBtn) {
+            console.warn("WizardManager Skeleton V4: One or more navigation/close buttons for the wizard modal are missing.");
         }
 
         window.FlowWare = window.FlowWare || {};
-        window.FlowWare.WizardManager = this; // Asignación global
+        window.FlowWare.WizardManager = this;
 
-        // Llamar a la lógica de visualización inicial desde aquí
-        // Asegurarse de que las dependencias para initDisplayLogic (FlowWare.Utils) estén listas.
-        // app.js ya verifica esto antes de instanciar WizardManager.
+        this.initBaseListenersInSkeleton();
         this.initDisplayLogic();
+        console.log("WizardManager Skeleton V4: Constructor finished.");
     }
 
     initDisplayLogic() {
-        console.log("WizardManager Skeleton: initDisplayLogic() CALLED.");
+        console.log("WizardManager Skeleton V4: initDisplayLogic() CALLED.");
+
         if (!window.FlowWare || !window.FlowWare.Utils || !window.FlowWare.Utils.State) {
-             console.error("WizardManager Skeleton: FlowWare.Utils.State is not available in initDisplayLogic. Cannot determine wizard completion state.");
-             const msgContainer = document.getElementById('initial-config-message');
-             if (msgContainer) {
-                msgContainer.innerHTML = "<p style='color:red;'>Error: Dependencias de FlowWare.Utils no cargadas. Wizard no puede continuar.</p>";
-                msgContainer.style.display = 'flex';
+             console.error("WizardManager Skeleton V4: FlowWare.Utils.State is not available. Cannot determine wizard completion state.");
+             if (this.initialConfigMessage) {
+                this.initialConfigMessage.innerHTML = "<p style='color:red;'>Error: Dependencias críticas (FlowWare.Utils.State) no cargadas. El asistente no puede continuar.</p>";
+                this.initialConfigMessage.style.display = 'flex';
              }
-             if (this.wizardElement) this.wizardElement.style.display = 'none'; // Ocultar wizard si hay error
+             if (this.wizardElement) this.wizardElement.style.display = 'none';
              return;
+        }
+        console.log("WizardManager Skeleton V4: FlowWare.Utils.State IS available.");
+
+        if (this.reopenWizardBtn) {
+            const newReopenBtn = this.reopenWizardBtn.cloneNode(true);
+            if (this.reopenWizardBtn.parentNode) {
+                this.reopenWizardBtn.parentNode.replaceChild(newReopenBtn, this.reopenWizardBtn);
+            }
+            this.reopenWizardBtn = newReopenBtn;
+            this.reopenWizardBtn.addEventListener('click', () => {
+                console.log("WizardManager Skeleton V4: reopenWizardBtn clicked.");
+                this.showWizard(true);
+            });
+            console.log("WizardManager Skeleton V4: reopenWizardBtn listener attached.");
+        } else {
+            console.warn("WizardManager Skeleton V4: #reopen-wizard-btn not found during initDisplayLogic. Reopening from message will not work.");
         }
 
         const wizardCompleted = window.FlowWare.Utils.State.load('flowWareConfig.wizardCompleted');
-        const initialConfigMessage = document.getElementById('initial-config-message');
+        console.log(`WizardManager Skeleton V4: wizardCompleted flag from localStorage is: ${wizardCompleted}`);
 
         if (!wizardCompleted) {
-            console.log("WizardManager Skeleton: Wizard not completed, attempting to show wizard.");
-            this.showWizard();
+            console.log("WizardManager Skeleton V4: Configuration not complete. Attempting to show wizard.");
+            this.showWizard(false);
         } else {
-            console.log("WizardManager Skeleton: Wizard completed, showing message.");
-            if (initialConfigMessage) initialConfigMessage.style.display = 'flex';
-            this.hideWizard();
+            console.log("WizardManager Skeleton V4: Configuration IS complete. Attempting to show completion message.");
+            if (this.initialConfigMessage) {
+                this.initialConfigMessage.style.display = 'flex';
+                console.log("WizardManager Skeleton V4: Completion message displayed.");
+            } else {
+                console.error("WizardManager Skeleton V4: #initial-config-message is null, cannot show completion message.");
+            }
+            this.hideWizard(); // Ensure wizard modal is hidden
         }
     }
 
-    showWizard() {
-        console.log("WizardManager Skeleton: showWizard() CALLED");
+    showWizard(isReopening = false) {
+        console.log(`WizardManager Skeleton V4: showWizard(isReopening: ${isReopening}) CALLED`);
+
+        if (this.initialConfigMessage) {
+            this.initialConfigMessage.style.display = 'none';
+        } else {
+            console.warn("WizardManager Skeleton V4: #initial-config-message not found in showWizard, cannot hide it.");
+        }
+
+        if (isReopening) {
+             console.log("WizardManager Skeleton V4: Reopening wizard logic...");
+             // const restartFresh = confirm("¿Desea borrar toda la configuración existente y empezar de cero, o solo revisar/editar?");
+             // if (restartFresh) { /* Lógica para limpiar localStorage y wizardCompleted flag */ }
+        }
+
         if (this.wizardElement) {
             this.wizardElement.classList.add('active');
-            // Ocultar el mensaje de "configuración completada" si se muestra el wizard
-            const initialConfigMessage = document.getElementById('initial-config-message');
-            if (initialConfigMessage) {
-                initialConfigMessage.style.display = 'none';
-            }
+            console.log("WizardManager Skeleton V4: Wizard modal activated.");
+            // En una versión completa, aquí se inicializaría el primer paso:
+            // this.currentStep = 0;
+            // this.initializeStep(1);
+            // this.updateStepVisibility();
+            // this.updateButtonStates();
         } else {
-            console.error("WizardManager Skeleton: Cannot show wizard, #config-wizard element not found.");
+            console.error("WizardManager Skeleton V4: #config-wizard element not found. CANNOT SHOW WIZARD.");
         }
     }
 
     hideWizard() {
-        console.log("WizardManager Skeleton: hideWizard() CALLED");
+        console.log("WizardManager Skeleton V4: hideWizard() CALLED");
         if (this.wizardElement) {
             this.wizardElement.classList.remove('active');
+            console.log("WizardManager Skeleton V4: Wizard modal deactivated.");
         } else {
-            console.error("WizardManager Skeleton: Cannot hide wizard, #config-wizard element not found.");
+            console.warn("WizardManager Skeleton V4: #config-wizard not found in hideWizard.");
         }
     }
 
-    // Todos los demás métodos de la clase WizardManager (init, changeStep, validateStepX, saveStepXState, loadStepXState, etc.)
-    // están OMITIDOS en esta versión esqueleto para aislar el problema de definición de la clase.
-    // Si esta versión esqueleto funciona (es decir, app.js no da error de "WizardManager no definido"),
-    // entonces el error de sintaxis está en el código omitido.
+    initBaseListenersInSkeleton() {
+        if(this.closeWizardBtn) {
+            this.closeWizardBtn.addEventListener('click', () => {
+                console.log("Skeleton V4: closeWizardBtn clicked");
+                const wizardCompleted = window.FlowWare && window.FlowWare.Utils ? window.FlowWare.Utils.State.load('flowWareConfig.wizardCompleted') : false;
+                if(!wizardCompleted) {
+                    const msg = "Debe completar la configuración inicial para cerrar el asistente.";
+                    if(window.FlowWare && window.FlowWare.NotificationManager) window.FlowWare.NotificationManager.show(msg, "warning");
+                    else alert(msg);
+                } else {
+                    this.hideWizard();
+                    if(this.initialConfigMessage) this.initialConfigMessage.style.display = 'flex';
+                }
+            });
+        }
+        if(this.prevBtn) this.prevBtn.addEventListener('click', () => console.log("Skeleton V4: prevBtn clicked."));
+        if(this.nextBtn) this.nextBtn.addEventListener('click', () => console.log("Skeleton V4: nextBtn clicked."));
+        if(this.finishBtn) {
+            this.finishBtn.addEventListener('click', () => {
+                console.log("Skeleton V4: finishBtn clicked");
+                if(window.FlowWare && window.FlowWare.Utils) {
+                    window.FlowWare.Utils.State.save('flowWareConfig.wizardCompleted', true);
+                }
+                this.hideWizard();
+                if(this.initialConfigMessage) this.initialConfigMessage.style.display = 'flex';
+            });
+        }
+    }
 }
-console.log("wizard-manager.js: Script end parsing. WizardManager class SHOULD BE defined now (Skeleton Version).");
 
-// No auto-instanciar WizardManager aquí. app.js es responsable de la instanciación.
-// La línea `window.FlowWare.WizardManager = this;` está DENTRO del constructor.
-// La clase WizardManager en sí misma está disponible globalmente porque no está envuelta en un IIFE.
-// app.js puede hacer `new WizardManager();` siempre que este script se cargue primero.
+window.WizardManagerClassDefined = true;
+console.log("wizard-manager.js (Skeleton V4): Script end parsing. Class WizardManager defined. window.WizardManagerClassDefined set to true.");


### PR DESCRIPTION
- Sobrescrito wizard-manager.js con una versión esqueleto (V4) que incluye logs detallados y lógica de visualización inicial simplificada. El constructor llama a initDisplayLogic.
- Sobrescrito app.js con una versión esqueleto (V3) que verifica la bandera WizardManagerClassDefined antes de instanciar WizardManager.
- Confirmado que idx.html tiene el orden de scripts correcto (wizard-manager.js ANTES de app.js) y no tiene el app-header global.
- Los archivos y CSS del canvas permanecen eliminados.

Este commit es para depurar el error 'WizardManager no está definido' y verificar el flujo de inicio automático del wizard.