### PR TITLE
Refactor: Wizard se inicia automáticamente y no como modal

### DIFF
--- a/idx.html
+++ b/idx.html
@@ -21,17 +21,14 @@
             </button>
         </div>
 
-        <!-- El .app-content-wrapper, .sidebar, .workspace han sido eliminados -->
-        <!-- El único contenido principal visible será el #initial-config-message o el wizard modal -->
-
-    </div> <!-- Fin div.app -->
-
-    <!-- Wizard Modal -->
-    <div id="config-wizard" class="modal-overlay" style="display: none;">
-        <div class="modal-content" style="max-width: 700px; width: 90%;">
-            <div class="modal-header">
+        <!-- Contenedor del Wizard (ya no es un modal overlay) -->
+        <div id="config-wizard" style="display: none;">
+            <!-- La clase .modal-content ya no es necesaria como wrapper directo si #config-wizard es el contenedor principal con padding, etc. -->
+            <!-- O se puede mantener si #config-wizard es solo un flex container y .wizard-content (renombrado de .modal-content) tiene el bg, shadow, etc. -->
+            <!-- Por simplicidad, #config-wizard ahora tiene los estilos de .modal-overlay y .modal-content combinados -->
+            <div class="wizard-header"> <!-- Renombrado desde modal-header -->
                 <h2>Asistente de Configuración Inicial</h2>
-                <button id="close-wizard-btn" class="modal-close-btn">&times;</button> <!-- Botón para cerrar el wizard -->
+                <button id="close-wizard-btn" class="modal-close-btn">&times;</button>
             </div>
             <div class="wizard-steps">
                 <div class="wizard-step active" data-step="1">

--- a/styles/main.css
+++ b/styles/main.css
@@ -87,43 +87,22 @@ body {
     flex-direction: column;
     height: 100vh;
     background-color: var(--white);
+    /* overflow-y: auto; Permitir scroll en .app si el wizard es muy largo y no tiene su propio scroll */
 }
 
-.app-header {
-    padding: 10px 20px;
-    background-color: var(--gray-100); /* Ligeramente diferente para destacar */
-    border-bottom: 1px solid var(--gray-300); /* Borde más notorio */
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    z-index: 1000; /* Asegurar que esté por encima de otros elementos como el wizard overlay */
-    box-shadow: var(--shadow-sm);
-}
+/* Ya no hay app-header global */
 
-.app-header .logo {
-    font-size: 1.5em;
-    margin: 0;
-    color: var(--primary-blue);
-    display: flex;
-    align-items: center;
-}
-
-.app-header .logo-icon {
-    font-size: 1.5em; /* Ajustar si es necesario */
-    margin-right: var(--space-2);
-    color: var(--accent-orange);
-}
-
-/* Contenedor para el mensaje principal cuando el wizard está completo y el workspace oculto */
+/* Contenedor para el mensaje principal cuando el wizard está completo */
 .initial-config-message-container {
-    display: none; /* Oculto por defecto, se muestra con JS */
+    display: none; /* Oculto por defecto, JS lo mostrará */
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    flex-grow: 1; /* Para que ocupe el espacio restante bajo el app-header */
+    flex-grow: 1;
     text-align: center;
     padding: var(--space-8);
-    background-color: var(--gray-50); /* Un fondo suave */
+    background-color: var(--gray-50);
+    min-height: 300px; /* Asegurar que tenga algo de altura para ser visible */
 }
 
 .initial-config-message-container h2 {

--- a/styles/wizard.css
+++ b/styles/wizard.css
@@ -1,39 +1,29 @@
 /* styles/wizard.css */
 
-.modal-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: rgba(0, 0, 0, 0.6);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1050; /* Encima de otros elementos como el panel de config */
-    opacity: 0;
-    visibility: hidden;
-    transition: opacity 0.3s ease, visibility 0.3s ease;
-}
-
-.modal-overlay.active {
-    opacity: 1;
-    visibility: visible;
-}
-
-.modal-content {
-    background-color: #fff;
-    padding: 25px;
-    border-radius: 8px;
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
-    width: 90%;
-    max-width: 700px;
-    max-height: 90vh;
-    display: flex;
+/* Ya no es un modal overlay, sino el contenedor principal del wizard */
+#config-wizard {
+    display: none; /* Oculto por defecto, JS lo mostrará */
     flex-direction: column;
+    width: 100%;
+    max-width: 900px; /* Un ancho máximo para el contenido del wizard */
+    margin: 20px auto; /* Centrar y dar espacio arriba/abajo */
+    padding: 20px;
+    background-color: var(--white, #fff);
+    border: 1px solid var(--gray-300, #ccc);
+    border-radius: var(--radius-lg, 8px);
+    box-shadow: var(--shadow-lg, 0 10px 15px -3px rgba(0,0,0,0.1));
+    /* height: calc(100vh - 100px); /* Ajustar altura si es necesario, menos el espacio para header/footer si los hubiera */
+    /* overflow-y: auto; No es necesario si .wizard-steps lo tiene */
 }
 
-.modal-header {
+#config-wizard.active {
+    display: flex; /* Mostrar cuando esté activo */
+}
+
+/* El contenido del wizard (anteriormente .modal-content) ahora es directamente #config-wizard */
+/* Así que los estilos de .modal-content se aplican o se adaptan a #config-wizard */
+
+.wizard-header { /* Renombrado de .modal-header */
     display: flex;
     justify-content: space-between;
     align-items: center;


### PR DESCRIPTION
- Eliminado el app-header global de idx.html.
- El wizard (#config-wizard) ahora es un contenedor principal en la página, no un modal overlay.
- CSS actualizado en wizard.css y main.css para este nuevo layout.
- WizardManager.js (versión completa restaurada) maneja la lógica de visualización inicial:
  - Se muestra automáticamente si la configuración no está completa.
  - Muestra mensaje de 'configuración completada' con botón para reabrir/reiniciar si ya se completó.
  - Impide el cierre del wizard (vía 'x') si la configuración no ha sido finalizada.
- app.js es mínimo y solo instancia WizardManager.
- Corregidos errores de carga previos relacionados con la definición y orden de scripts.